### PR TITLE
refactor: make the workflow work again

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -2,6 +2,7 @@ name: 'GitHub Actions Weather Bot'
 
 on:
   push:
+  workflow_dispatch:
   schedule:
     - cron: '0 21 * * *'
 
@@ -23,7 +24,6 @@ jobs:
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: Shanghai Weather Report (${{env.REPORT_DATE}})
-          body: file://result.html
+          html_body: file://result.html
           to: yifeng.ruan@gmail.com
           from: GitHub Actions
-          content_type: text/html

--- a/weather.sh
+++ b/weather.sh
@@ -11,4 +11,4 @@ curl \
   -H "Accept-Language: $LANGUAGE" \
   -H "User-Agent: $UA" \
   -o result.html \
-  wttr.in/$CITY?format=4\&$UNIT
+  https://wttr.in/$CITY?format=4\&$UNIT


### PR DESCRIPTION
make the workflow work with latest weather API and latest GitHub actions

1. request the https:// of weather api otherwise you will get a 301 redirect to https html
2. add workflow_dispatch, otherwise you can't run the workflow manually
3. use html_body and remove content_type to match latest dawidd6/action-send-mail@master